### PR TITLE
Create personal portfolio landing experience

### DIFF
--- a/app/dashboard/customers/page.tsx
+++ b/app/dashboard/customers/page.tsx
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <p>Customers Page</p>;
-}

--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <p>Invoices Page</p>;
-}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,12 +1,14 @@
 import SideNav from '@/app/ui/dashboard/sidenav';
- 
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen flex-col md:flex-row md:overflow-hidden">
-      <div className="w-full flex-none md:w-64">
+    <div className="flex min-h-screen flex-col bg-slate-50 md:flex-row md:overflow-hidden">
+      <div className="w-full flex-none border-b border-slate-200 bg-white md:h-screen md:w-72 md:border-b-0 md:border-r">
         <SideNav />
       </div>
-      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">{children}</div>
+      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">
+        <div className="mx-auto flex max-w-5xl flex-col gap-12">{children}</div>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,62 @@
+import Image from 'next/image';
+
+const highlights = [
+  {
+    title: 'Crafting thoughtful experiences',
+    description:
+      'I translate complex ideas into intuitive products. My focus is on designing interfaces that feel effortless while still being technically robust.',
+  },
+  {
+    title: 'Full-stack foundations',
+    description:
+      'From data modeling to pixel-perfect layouts, I enjoy building each layer of a project and keeping the user experience front and center.',
+  },
+  {
+    title: 'Always learning',
+    description:
+      'Exploring new frameworks, tools, and ideas keeps my work fresh. Every project is a chance to experiment and grow.',
+  },
+];
+
 export default function Page() {
-  return <p>Dashboard Page</p>;
+  return (
+    <section className="grid gap-12 lg:grid-cols-[minmax(0,3fr),minmax(0,2fr)]">
+      <div className="space-y-8">
+        <div className="space-y-4">
+          <p className="text-sm uppercase tracking-[0.35em] text-blue-500">Hi there, I&apos;m</p>
+          <h1 className="text-4xl font-semibold text-slate-900 md:text-5xl">
+            Jonas Wahlberg
+          </h1>
+          <p className="max-w-2xl text-lg text-slate-600">
+            I design and build delightful digital products for the web. With a background in
+            product design and full-stack development, I thrive at the intersection of visuals,
+            usability, and clean code.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {highlights.map((highlight) => (
+            <article
+              key={highlight.title}
+              className="rounded-2xl border border-slate-200 bg-white/70 p-6 shadow-sm backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-md"
+            >
+              <h2 className="text-lg font-medium text-slate-900">{highlight.title}</h2>
+              <p className="mt-2 text-sm text-slate-600">{highlight.description}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+      <div className="relative flex items-center justify-center">
+        <div className="relative h-80 w-80 overflow-hidden rounded-[2.5rem] border border-slate-200 bg-slate-50 shadow-xl">
+          <Image
+            src="/profile-portrait.svg"
+            alt="Stylized illustration of Jonas Wahlberg"
+            fill
+            sizes="(min-width: 1024px) 320px, 60vw"
+            className="object-cover"
+            priority
+          />
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/app/dashboard/project-aurora/page.tsx
+++ b/app/dashboard/project-aurora/page.tsx
@@ -1,0 +1,19 @@
+export default function Page() {
+  return (
+    <section className="max-w-3xl space-y-6">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-[0.35em] text-blue-500">Case study</p>
+        <h1 className="text-3xl font-semibold text-slate-900 md:text-4xl">Project Aurora</h1>
+      </header>
+      <p className="text-slate-600">
+        Project Aurora is a concept for a calm, ambient productivity app that helps remote teams
+        stay in sync without adding noise to their day. I&apos;m exploring motion design, spatial audio,
+        and scheduling intelligence to create a focused workspace.
+      </p>
+      <p className="text-slate-600">
+        I&apos;m currently iterating on interactive prototypes and collecting feedback. Full case study
+        coming soon!
+      </p>
+    </section>
+  );
+}

--- a/app/dashboard/project-meridian/page.tsx
+++ b/app/dashboard/project-meridian/page.tsx
@@ -1,0 +1,19 @@
+export default function Page() {
+  return (
+    <section className="max-w-3xl space-y-6">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-[0.35em] text-blue-500">In development</p>
+        <h1 className="text-3xl font-semibold text-slate-900 md:text-4xl">Project Meridian</h1>
+      </header>
+      <p className="text-slate-600">
+        Project Meridian explores how data storytelling can empower climate researchers. I&apos;m
+        prototyping dashboards that turn real-time satellite data into approachable narratives for
+        policy makers and communities.
+      </p>
+      <p className="text-slate-600">
+        This page will document my design process, technical stack, and learnings as I shape the
+        MVP. Check back soon for updates!
+      </p>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,54 +1,5 @@
-import AcmeLogo from '@/app/ui/acme-logo';
-import { ArrowRightIcon } from '@heroicons/react/24/outline';
-import Link from 'next/link';
-import styles from '@/app/ui/home.module.css';
-import { lusitana } from '@/app/ui/fonts';
-import Image from 'next/image';
-
+import { redirect } from 'next/navigation';
 
 export default function Page() {
-  return (
-    <main className="flex min-h-screen flex-col p-6">
-      <div className="flex h-20 shrink-0 items-end rounded-lg bg-blue-500 p-4 md:h-52">
-        {/* <AcmeLogo /> */}
-      </div>
-      <div className="mt-4 flex grow flex-col gap-4 md:flex-row">
-        <div className="flex flex-col justify-center gap-6 rounded-lg bg-gray-50 px-6 py-10 md:w-2/5 md:px-20">
-	  
-	  <div className={styles.shape} />
-
-          <p className={`${lusitana.className} text-xl text-gray-800 md:text-3xl md:leading-normal`}>
-            <strong>Welcome to Acme.</strong> This is the example for the{' '}
-            <a href="https://nextjs.org/learn/" className="text-blue-500">
-              Next.js Learn Course
-            </a>
-            , brought to you by Vercel.
-          </p>
-          <Link
-            href="/login"
-            className="flex items-center gap-5 self-start rounded-lg bg-blue-500 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-400 md:text-base"
-          >
-            <span>Log in</span> <ArrowRightIcon className="w-5 md:w-6" />
-          </Link>
-        </div>
-        <div className="flex items-center justify-center p-6 md:w-3/5 md:px-28 md:py-12">
-          {/* Add Hero Images Here */}
-          <Image
-            src="/hero-desktop.png"
-            width={1000}
-            height={760}
-            className="hidden md:block"
-            alt="Screenshots of the dashboard project showing desktop version"
-          />
-          <Image
-            src="/hero-mobile.png"
-            width={560}
-            height={620}
-            className="block md:hidden"
-            alt="Screenshots of the dashboard project showing desktop version"
-          />
-        </div>
-      </div>
-    </main>
-  );
+  redirect('/dashboard');
 }

--- a/app/ui/acme-logo.tsx
+++ b/app/ui/acme-logo.tsx
@@ -1,13 +1,14 @@
-import { GlobeAltIcon } from '@heroicons/react/24/outline';
+import { SparklesIcon } from '@heroicons/react/24/solid';
 import { lusitana } from '@/app/ui/fonts';
 
 export default function AcmeLogo() {
   return (
-    <div
-      className={`${lusitana.className} flex flex-row items-center leading-none text-white`}
-    >
-      <GlobeAltIcon className="h-12 w-12 rotate-[15deg]" />
-      <p className="text-[44px]">Acme</p>
+    <div className={`${lusitana.className} flex flex-col gap-2 text-white`}>
+      <div className="flex items-center gap-2 text-sm uppercase tracking-[0.35em]">
+        <SparklesIcon className="h-5 w-5" />
+        <span>Portfolio</span>
+      </div>
+      <p className="text-3xl font-semibold leading-none md:text-4xl">Jonas Wahlberg</p>
     </div>
   );
 }

--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -1,47 +1,52 @@
 'use client';
 
 import {
-  UserGroupIcon,
   HomeIcon,
-  DocumentDuplicateIcon,
+  SparklesIcon,
+  RocketLaunchIcon,
 } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 
-// Map of links to display in the side navigation.
-// Depending on the size of the application, this would be stored in a database.
 const links = [
-  { name: 'Home', href: '/dashboard', icon: HomeIcon },
+  { name: 'About', href: '/dashboard', icon: HomeIcon },
   {
-    name: 'Invoices',
-    href: '/dashboard/invoices',
-    icon: DocumentDuplicateIcon,
+    name: 'Project Aurora',
+    href: '/dashboard/project-aurora',
+    icon: SparklesIcon,
   },
-  { name: 'Customers', href: '/dashboard/customers', icon: UserGroupIcon },
+  {
+    name: 'Project Meridian',
+    href: '/dashboard/project-meridian',
+    icon: RocketLaunchIcon,
+  },
 ];
 
 export default function NavLinks() {
   const pathname = usePathname();
   return (
-    <>
+    <nav className="flex flex-col space-y-2">
       {links.map((link) => {
         const LinkIcon = link.icon;
+        const isActive = pathname === link.href;
         return (
           <Link
             key={link.name}
             href={link.href}
             className={clsx(
-              'flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3',
+              'flex h-[48px] items-center gap-3 rounded-xl px-4 text-sm font-medium transition-colors md:h-12',
               {
-                'bg-sky-100 text-blue-600': pathname === link.href,
+                'bg-blue-600 text-white shadow': isActive,
+                'bg-white text-slate-600 hover:bg-slate-100': !isActive,
               },
-            )}          >
-            <LinkIcon className="w-6" />
-            <p className="hidden md:block">{link.name}</p>
+            )}
+          >
+            <LinkIcon className="w-5" />
+            <span>{link.name}</span>
           </Link>
         );
       })}
-    </>
+    </nav>
   );
 }

--- a/app/ui/dashboard/sidenav.tsx
+++ b/app/ui/dashboard/sidenav.tsx
@@ -1,28 +1,28 @@
 import Link from 'next/link';
 import NavLinks from '@/app/ui/dashboard/nav-links';
 import AcmeLogo from '@/app/ui/acme-logo';
-import { PowerIcon } from '@heroicons/react/24/outline';
+import { EnvelopeIcon } from '@heroicons/react/24/outline';
 
 export default function SideNav() {
   return (
-    <div className="flex h-full flex-col px-3 py-4 md:px-2">
+    <div className="flex h-full flex-col gap-6 px-3 py-4 md:px-2">
       <Link
-        className="mb-2 flex h-20 items-end justify-start rounded-md bg-blue-600 p-4 md:h-40"
-        href="/"
+        className="flex h-20 items-end justify-start rounded-md bg-gradient-to-r from-blue-600 to-purple-600 p-4 text-white shadow md:h-40"
+        href="/dashboard"
       >
-        <div className="w-32 text-white md:w-40">
+        <div className="w-full text-white md:w-40">
           <AcmeLogo />
         </div>
       </Link>
-      <div className="f lex grow flex-row justify-between space-x-2 md:flex-col md:space-x-0 md:space-y-2">
+      <div className="flex grow flex-col justify-between space-y-6">
         <NavLinks />
-        <div className="hidden h-auto w-full grow rounded-md bg-gray-50 md:block"></div>
-        <form>
-          <button className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
-            <PowerIcon className="w-6" />
-            <div className="hidden md:block">Sign Out</div>
-          </button>
-        </form>
+        <Link
+          href="mailto:hello@wahlberg.moe"
+          className="flex items-center justify-center gap-2 rounded-xl border border-blue-100 bg-white p-3 text-sm font-medium text-blue-600 transition hover:border-blue-200 hover:bg-blue-50 md:justify-between"
+        >
+          <span className="hidden md:inline">Let&apos;s collaborate</span>
+          <EnvelopeIcon className="h-5 w-5" />
+        </Link>
       </div>
     </div>
   );

--- a/app/ui/home.module.css
+++ b/app/ui/home.module.css
@@ -1,7 +1,0 @@
-.shape {
-  height: 0;
-  width: 0;
-  border-bottom: 30px solid black;
-  border-left: 20px solid transparent;
-  border-right: 20px solid transparent;
-}

--- a/public/profile-portrait.svg
+++ b/public/profile-portrait.svg
@@ -1,0 +1,18 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#9333ea" />
+    </linearGradient>
+    <linearGradient id="shirt" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc" />
+      <stop offset="100%" stop-color="#cbd5f5" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="48" fill="url(#gradient)"/>
+  <circle cx="256" cy="192" r="112" fill="#f8fafc" fill-opacity="0.9"/>
+  <circle cx="256" cy="200" r="72" fill="#0f172a" fill-opacity="0.85"/>
+  <rect x="128" y="288" width="256" height="176" rx="88" fill="url(#shirt)" fill-opacity="0.92"/>
+  <path d="M180 392C204 352 236 336 256 336C276 336 308 352 332 392" stroke="#64748b" stroke-width="20" stroke-linecap="round"/>
+  <path d="M208 208C216 224 236 232 256 232C276 232 296 224 304 208" stroke="#e2e8f0" stroke-width="20" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- redirect the root route to the dashboard so visitors land on the portfolio experience immediately
- redesign the dashboard home into an about page with highlights, custom branding, and an illustration asset
- refresh the sidebar navigation for future projects and add two project placeholder pages plus contact link

## Testing
- pnpm build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c744b5408325b56251b69508caa2